### PR TITLE
18_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'activeadmin'
 gem 'kaminari'
+gem 'redcarpet', '~> 2.3.0'
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -257,6 +258,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -269,6 +271,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -3,4 +3,9 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
+  def show
+    @aws_text = AwsText.find(params[:id]) 
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
-end
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0] if language.preset?
+
+      case language.to_s
+      when 'rb'
+        lang = :ruby
+      when 'yml'
+        lang = :yaml
+      when 'css'
+        lang = :css
+      when 'html'
+        lang = :html
+      when ''
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank"}
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_block: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text)
+  end
+end 

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -13,7 +13,7 @@
       <% @aws_texts.each.with_index(1) do |aws_text,i| %>
       <tr>
         <th scope="row"><%= i %></th>
-        <td><%= aws_text.title %></td>
+        <td><%= link_to aws_text.title, aws_text_path(id:aws_text) %></td>
       </tr>
       <% end %>
     </tbody>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -13,7 +13,7 @@
       <% @aws_texts.each.with_index(1) do |aws_text,i| %>
       <tr>
         <th scope="row"><%= i %></th>
-        <td><%= link_to aws_text.title, aws_text_path(id:) %></td>
+        <td><%= link_to aws_text.title, aws_text %></td>
       </tr>
       <% end %>
     </tbody>

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -13,7 +13,7 @@
       <% @aws_texts.each.with_index(1) do |aws_text,i| %>
       <tr>
         <th scope="row"><%= i %></th>
-        <td><%= link_to aws_text.title, aws_text_path(id:aws_text) %></td>
+        <td><%= link_to aws_text.title, aws_text_path(id:) %></td>
       </tr>
       <% end %>
     </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,7 +1,1 @@
-<%
-  text =<<~TEXT
-    #{@aws_text.content }
-  TEXT
-%>
-
-<%= markdown(text).html_safe %>
+<%= markdown(@aws_text.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,7 @@
+<%
+  text =<<~TEXT
+    #{@aws_text.content }
+  TEXT
+%>
+
+<%= markdown(text).html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   root "movies#index"
   resources :questions
 
-  resources :aws_texts, only: :index
+  resources :aws_texts, only: [:index, :show]
 
 end


### PR DESCRIPTION
・AWSテキスト教材の詳細ページを作成
・詳細ページにMarkdownを適用
参考資料「逆転教材＿Markdownの導入」